### PR TITLE
Potential fix for code scanning alert no. 3: Regular expression injection

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
 const { Octokit } = require('@octokit/action');
+const _ = require('lodash');
 
 const cancelAction = async () => {
     if (core.getInput('GITHUB_TOKEN')) {
@@ -69,7 +70,8 @@ const runAction = async () => {
             throw new Error('Potentially dangerous regex pattern detected');
         }
 
-        preview_url_regexp = new RegExp(preview_url_pattern);
+        const sanitizedPattern = _.escapeRegExp(preview_url_pattern);
+        preview_url_regexp = new RegExp(sanitizedPattern);
     } catch (error) {
         console.log('Invalid or unsafe regular expression pattern.', {
             pattern: preview_url_pattern,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
         "@actions/core": "^1.9.1",
         "@actions/github": "^6.0.1",
         "@deriv/deriv-api": "^1.0.10",
-        "@octokit/action": "^6.0.7"
+        "@octokit/action": "^6.0.7",
+        "lodash": "^4.17.21"
     },
     "devDependencies": {
         "husky": "^4.3.8",


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/vercel-preview-url-action/security/code-scanning/3](https://github.com/deriv-com/vercel-preview-url-action/security/code-scanning/3)

To fix the issue, the user input (`preview_url_pattern`) should be sanitized before being used to construct the regular expression. This can be achieved by using a library like `lodash` and its `_.escapeRegExp` function to escape special characters in the input. This ensures that the input cannot modify the meaning of the regular expression. The fix involves:
1. Importing `lodash` in the file.
2. Escaping the `preview_url_pattern` using `_.escapeRegExp` before passing it to the `RegExp` constructor.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
